### PR TITLE
Application code should avoid starting threads.

### DIFF
--- a/lib/rubocop-thread_safety.rb
+++ b/lib/rubocop-thread_safety.rb
@@ -4,3 +4,4 @@ require 'rubocop/thread_safety/version'
 
 require 'rubocop/cop/thread_safety/instance_variable_in_class_method'
 require 'rubocop/cop/thread_safety/class_and_module_attributes'
+require 'rubocop/cop/thread_safety/new_thread'

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ThreadSafety
+      class NewThread < Cop
+        MSG = 'Avoid starting new threads.'.freeze
+
+        def_node_matcher :new_thread?, <<-END
+          (send (const nil :Thread) :new)
+        END
+
+        def on_send(node)
+          return unless new_thread?(node)
+          add_offense(node, :expression, format(MSG, node.source))
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/thread_safety/new_thread_spec.rb
+++ b/spec/rubocop/cop/thread_safety/new_thread_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ThreadSafety::NewThread do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense for starting a new thread' do
+    inspect_source(cop, 'Thread.new { do_work }')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages)
+      .to eq(['Avoid starting new threads.'])
+    expect(cop.highlights).to eq(['Thread.new'])
+  end
+
+  it 'does not register an offense for calling new on other classes' do
+    inspect_source(cop, 'Other.new { do_work }')
+    expect(cop.offenses.size).to eq(0)
+  end
+end


### PR DESCRIPTION
Applications should use a threaded web server, Sidekiq, Celluloid, or some other framework to manage threads.