### PR TITLE
Remove the requirement for a rubocop submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/rubocop"]
-	path = vendor/rubocop
-	url = https://github.com/bbatsov/rubocop

--- a/bin/setup
+++ b/bin/setup
@@ -4,6 +4,3 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-
-git submodule add git@github.com:bbatsov/rubocop vendor/rubocop || true
-git submodule update --init --depth 1 vendor/rubocop

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop', '>= 0.41.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,7 @@ end
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rubocop-thread_safety'
 
-rubocop_path = File.join(File.dirname(__FILE__), '../vendor/rubocop')
-
-unless File.directory?(rubocop_path)
-  abort 'Run `bin/setup` to get a working development environment.'
-end
-
-Dir["#{rubocop_path}/spec/support/**/*.rb"].each { |f| require f }
+require 'rubocop/rspec/support'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
The latest release of RuboCop (v0.41.1) exposes files to support testing with RSpec.

Shamelessly copied from https://github.com/nevir/rubocop-rspec/pull/109.