### PR TITLE
Update for RuboCop 0.47.0

### DIFF
--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -51,7 +51,7 @@ module RuboCop
 
         def singleton_method_definition?(node)
           node.ancestors.any? do |ancestor|
-            next unless ancestor.children.first.is_a? Node
+            next unless ancestor.children.first.is_a? AST::Node
             ancestor.children.first.command? :define_singleton_method
           end
         end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.41.1'
+  spec.add_runtime_dependency 'rubocop', '>= 0.47.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
+RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do # rubocop:disable Metrics/BlockLength, Metrics/LineLength
   subject(:cop) { described_class.new }
 
   it 'registers an offense for `attr` in the singleton class' do

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
+RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do # rubocop:disable Metrics/BlockLength, Metrics/LineLength
   subject(:cop) { described_class.new }
 
   it 'registers an offense for assigning to an ivar in a class method' do


### PR DESCRIPTION
`Node` was refactored to `AST::Node` in https://github.com/bbatsov/rubocop/pull/3863

fixes #10