### PR TITLE
Fix for Rubocop 0.48.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Metrics/BlockLength:
 Style/FileName:
   Exclude:
     - lib/rubocop-thread_safety.rb
+    - rubocop-thread_safety.gemspec
 
 # Enable more cops that are disabled by default:
 

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -51,7 +51,7 @@ module RuboCop
 
         def singleton_method_definition?(node)
           node.ancestors.any? do |ancestor|
-            next unless ancestor.children.first.is_a? AST::Node
+            next unless ancestor.children.first.is_a? AST::SendNode
             ancestor.children.first.command? :define_singleton_method
           end
         end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rubocop/thread_safety/version'
@@ -14,14 +15,17 @@ Gem::Specification.new do |spec|
     Thread-safety checks via static analysis.
     A plugin for the RuboCop code style enforcing & linting tool.
   end_description
-  spec.homepage      = 'https://github.com/covermymeds/rubocop-thread_safety'
+  spec.homepage = 'https://github.com/covermymeds/rubocop-thread_safety'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.47.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.48.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Not all `Node`s respond to `#command?` now.