### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install the gem:
 
 Scan the application for just thread-safety issues:
 
-    $ rubocop -r rubocop-thread_safety --only Threadsafety,Style/GlobalVars,Style/ClassVars,Style/MutableConstant
+    $ rubocop -r rubocop-thread_safety --only ThreadSafety,Style/GlobalVars,Style/ClassVars,Style/MutableConstant
 
 ## Development
 


### PR DESCRIPTION
**Before:**

```
$ bin/rubocop --only Threadsafety,Style/GlobalVars,Style/ClassVars,Style/MutableConstant
Inspecting 309 files


0 files inspected, no offenses detected
Unrecognized cop or department: Threadsafety.
```

**After:**

```
$ bin/rubocop --only ThreadSafety,Style/GlobalVars,Style/ClassVars,Style/MutableConstant
Inspecting 309 files
.....................................................................................................................................................................................................................................................................................................................

309 files inspected, no offenses detected
$ 
```
