### PR TITLE
Fix: require powerpack for strip_ident and update ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,5 @@
 AllCops:
   DisplayCopNames: true
-  Include:
-    - Gemfile
-    - Rakefile
-  Exclude:
-    - vendor/**/*
 
 Metrics/BlockLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,16 @@ cache: bundler
 language: ruby
 rvm:
   - jruby-9.1.14.0
-  - 2.1
-  - 2.2
   - 2.3.0
   - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 
 matrix:
   fast_finish: true
 
-before_install: gem install --remote bundler -v '1.17.3'
+before_install: gem install --remote bundler
 install:
   - bundle install --retry=3
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 matrix:
   fast_finish: true
 
-before_install: gem install --remote bundler
+before_install: gem install --remote bundler -v '1.17.3'
 install:
   - bundle install --retry=3
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rubocop-thread_safety.gemspec

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2016-2017 CoverMyMeds
+Copyright 2016-2020 CoverMyMeds
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/coverm
 
 ## Copyright
 
-Copyright (c) 2016-2017 CoverMyMeds.
+Copyright (c) 2016-2020 CoverMyMeds.
 See [LICENSE.txt](LICENSE.txt) for further details.

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'rubocop-thread_safety'
 

--- a/lib/rubocop-thread_safety.rb
+++ b/lib/rubocop-thread_safety.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 
 require 'rubocop/thread_safety/version'

--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -13,7 +13,7 @@ module RuboCop
       #     cattr_accessor :current_user
       #   end
       class ClassAndModuleAttributes < Cop
-        MSG = 'Avoid mutating class and module attributes.'.freeze
+        MSG = 'Avoid mutating class and module attributes.'
 
         def_node_matcher :mattr?, <<-MATCHER
           (send nil?
@@ -29,6 +29,7 @@ module RuboCop
 
         def on_send(node)
           return unless mattr?(node) || singleton_attr?(node)
+
           add_offense(node, message: MSG)
         end
 

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -14,7 +14,7 @@ module RuboCop
       #     end
       #   end
       class InstanceVariableInClassMethod < Cop
-        MSG = 'Avoid instance variables in class methods.'.freeze
+        MSG = 'Avoid instance variables in class methods.'
 
         def on_ivar(node)
           return unless class_method_definition?(node)
@@ -43,7 +43,7 @@ module RuboCop
             ancestor.type == :def
           end
 
-          defn && defn.ancestors.any? do |ancestor|
+          defn&.ancestors&.any? do |ancestor|
             ancestor.type == :sclass
           end
         end
@@ -51,6 +51,7 @@ module RuboCop
         def singleton_method_definition?(node)
           node.ancestors.any? do |ancestor|
             next unless ancestor.children.first.is_a? AST::SendNode
+
             ancestor.children.first.command? :define_singleton_method
           end
         end
@@ -58,6 +59,7 @@ module RuboCop
         def synchronized?(node)
           node.ancestors.find do |ancestor|
             next unless ancestor.block_type?
+
             s = ancestor.children.first
             s.send_type? && s.children.last == :synchronize
           end

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -11,7 +11,7 @@ module RuboCop
       #   # bad
       #   Thread.new { do_work }
       class NewThread < Cop
-        MSG = 'Avoid starting new threads.'.freeze
+        MSG = 'Avoid starting new threads.'
 
         def_node_matcher :new_thread?, <<-MATCHER
           (send (const nil? :Thread) :new)
@@ -19,6 +19,7 @@ module RuboCop
 
         def on_send(node)
           return unless new_thread?(node)
+
           add_offense(node, message: MSG)
         end
       end

--- a/lib/rubocop/thread_safety/version.rb
+++ b/lib/rubocop/thread_safety/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module RuboCop
   module ThreadSafety
-    VERSION = '0.3.4'.freeze
+    VERSION = '0.3.4'
   end
 end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'pry' unless ENV['CI']
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'powerpack', '~> 0.1'
 end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rubocop', '>= 0.51.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'pry' unless ENV['CI']
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -1,4 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rubocop/thread_safety/version'
 
@@ -27,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop', '>= 0.51.0'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
+  spec.add_development_dependency 'powerpack', '~> 0.1'
   spec.add_development_dependency 'pry' unless ENV['CI']
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'powerpack', '~> 0.1'
 end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry' unless ENV['CI']
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'powerpack', '~> 0.1'
 end

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'the LICENSE' do

--- a/spec/rubocop/thread_safety_spec.rb
+++ b/spec/rubocop/thread_safety_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::ThreadSafety do
   it 'has a version number' do
     expect(RuboCop::ThreadSafety::VERSION).not_to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 begin
   require 'pry'
-rescue LoadError # rubocop:disable Lint/HandleExceptions
+rescue LoadError
   # Pry isn't installed in CI.
 end
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'rubocop-thread_safety'
 
 require 'powerpack/string/strip_indent'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ end
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rubocop-thread_safety'
 
+require 'powerpack/string/strip_indent'
 require 'rubocop/rspec/support'
 
 RSpec.configure do |config|


### PR DESCRIPTION
If we require ruby >= 2.3 then we can use `<<~` heredocs to strip indentation.

For now, at least bring back powerpack for `strip_indent` method as it was removed from rubocop's dependencies in rubocop `0.66.0`

Also, bump the copyright year to include 2020 as the specs require it to be current.