### PR TITLE
Detect instance_variable_[gs]et in class method

### DIFF
--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
-  it 'registers an offense for instance_variable_get in a class method' do
+  it 'registers an offense for ivar_get in a class method' do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         def self.some_method
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
-  it 'registers an offense for instance_variable_set in a class singleton method' do
+  it 'registers an offense for ivar_set in a class singleton method' do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         class << self
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
-  it 'registers an offense for instance_variable_set in define_singleton_method' do
+  it 'registers an offense for ivar_set in define_singleton_method' do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         define_singleton_method(:some_method) do |params|
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
-  it 'registers no offense for using instance_variable_get on another object in a class method' do
+  it 'registers no offense for using ivar_get on object in a class method' do
     expect_no_offenses(<<-RUBY.strip_indent)
       class Test
         def self.some_method(obj, params)
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
-  it 'registers no offense for using instance_variable_set on another object in a class method' do
+  it 'registers no offense for using ivar_set on object in a class method' do
     expect_no_offenses(<<-RUBY.strip_indent)
       class Test
         class << self
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
-  it 'registers no offense for using instance_variable_ methods in an instance method' do
+  it 'registers no offense for using ivar methods in an instance method' do
     expect_no_offenses(<<-RUBY.strip_indent)
       class Test
         def some_method(params)

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -74,12 +74,80 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
+  it 'registers an offense for instance_variable_get in a class method' do
+    expect_offense(<<-RUBY.strip_indent)
+      class Test
+        def self.some_method
+          do_work(instance_variable_get(:@params))
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for instance_variable_set in a class singleton method' do
+    expect_offense(<<-RUBY.strip_indent)
+      class Test
+        class << self
+          def some_method(name, params)
+            instance_variable_set(:"@\#{name}", params)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for instance_variable_set in define_singleton_method' do
+    expect_offense(<<-RUBY.strip_indent)
+      class Test
+        define_singleton_method(:some_method) do |params|
+          instance_variable_set(:@params, params)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense for using instance_variable_get on another object in a class method' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      class Test
+        def self.some_method(obj, params)
+          obj.instance_variable_get(:@params)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense for using instance_variable_set on another object in a class method' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      class Test
+        class << self
+          def some_method(obj, params)
+            obj.instance_variable_set(:@params, params)
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'registers no offense for using an ivar in an instance method' do
     expect_no_offenses(<<-RUBY.strip_indent)
       class Test
         def some_method(params)
           @params = params
           do_work(@params)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense for using instance_variable_ methods in an instance method' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      class Test
+        def some_method(params)
+          instance_variable_set(:@params, params)
+          do_work(instance_variable_get(:@params))
         end
       end
     RUBY


### PR DESCRIPTION
Detect another syntax for using class instance variables in a class method:
`instance_variable_get` and `instance_variable_set`.