### PR TITLE
Detect class_attribute from activesupport

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -34,7 +34,8 @@ module RuboCop
         MATCHER
 
         def on_send(node)
-          return unless mattr?(node) || class_attr?(node) || singleton_attr?(node)
+          return unless mattr?(node) || class_attr?(node) ||
+                        singleton_attr?(node)
 
           add_offense(node, message: MSG)
         end

--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -27,8 +27,14 @@ module RuboCop
             ...)
         MATCHER
 
+        def_node_matcher :class_attr?, <<-MATCHER
+          (send nil?
+            :class_attribute
+            ...)
+        MATCHER
+
         def on_send(node)
-          return unless mattr?(node) || singleton_attr?(node)
+          return unless mattr?(node) || class_attr?(node) || singleton_attr?(node)
 
           add_offense(node, message: MSG)
         end

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -82,6 +82,15 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     RUBY
   end
 
+  it 'registers an offense for `class_attribute`' do
+    expect_offense(<<-RUBY.strip_indent)
+      class Test
+        class_attribute :foobar
+        ^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+      end
+    RUBY
+  end
+
   it 'registers no offense for other class macro calls' do
     expect_no_offenses(<<-RUBY.strip_indent)
       class Test


### PR DESCRIPTION
`class_attribute` is similar to `mattr_accessor` and is also defined by activesupport. The difference is that `class_attribute` allows child classes to modify their own copy (and uses class instance variables instead of class variables to achieve it).