### PR TITLE
Detect attr_internal

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -27,6 +27,12 @@ module RuboCop
             ...)
         MATCHER
 
+        def_node_matcher :attr_internal?, <<-MATCHER
+          (send nil?
+            {:attr_internal :attr_internal_accessor :attr_internal_writer}
+            ...)
+        MATCHER
+
         def_node_matcher :class_attr?, <<-MATCHER
           (send nil?
             :class_attribute
@@ -43,7 +49,8 @@ module RuboCop
         private
 
         def singleton_attr?(node)
-          attr?(node) && node.ancestors.map(&:type).include?(:sclass)
+          (attr?(node) || attr_internal?(node)) &&
+            node.ancestors.map(&:type).include?(:sclass)
         end
       end
     end

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -46,6 +46,49 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     RUBY
   end
 
+  it 'registers an offense for `attr_internal` in the singleton class' do
+    expect_offense(<<-RUBY.strip_indent)
+      module Test
+        class << self
+          attr_internal :foobar
+          ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `attr_internal_accessor` in the singleton class' do
+    expect_offense(<<-RUBY.strip_indent)
+      module Test
+        class << self
+          attr_internal_accessor :foobar
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `attr_internal_writer` in the singleton class' do
+    expect_offense(<<-RUBY.strip_indent)
+      module Test
+        class << self
+          attr_internal_writer :foobar
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers no offense for `attr_internal_reader` in the singleton class' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      module Test
+        class << self
+          attr_internal_reader :foobar
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense for `mattr_writer`' do
     expect_offense(<<-RUBY.strip_indent)
       module Test

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   subject(:cop) { described_class.new }
+  let(:msg) { 'Avoid mutating class and module attributes.' }
 
   context 'when in the singleton class' do
     it 'registers an offense for `attr`' do
@@ -9,7 +10,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         module Test
           class << self
             attr :foobar
-            ^^^^^^^^^^^^ Avoid mutating class and module attributes.
+            ^^^^^^^^^^^^ #{msg}
           end
         end
       RUBY
@@ -20,7 +21,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         module Test
           class << self
             attr_accessor :foobar
-            ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+            ^^^^^^^^^^^^^^^^^^^^^ #{msg}
           end
         end
       RUBY
@@ -31,7 +32,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         module Test
           class << self
             attr_writer :foobar
-            ^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+            ^^^^^^^^^^^^^^^^^^^ #{msg}
           end
         end
       RUBY
@@ -52,7 +53,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         module Test
           class << self
             attr_internal :foobar
-            ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+            ^^^^^^^^^^^^^^^^^^^^^ #{msg}
           end
         end
       RUBY
@@ -63,7 +64,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         module Test
           class << self
             attr_internal_accessor :foobar
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
           end
         end
       RUBY
@@ -74,7 +75,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         module Test
           class << self
             attr_internal_writer :foobar
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
           end
         end
       RUBY
@@ -95,7 +96,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     expect_offense(<<-RUBY.strip_indent)
       module Test
         mattr_writer :foobar
-        ^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        ^^^^^^^^^^^^^^^^^^^^ #{msg}
       end
     RUBY
   end
@@ -104,7 +105,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     expect_offense(<<-RUBY.strip_indent)
       module Test
         mattr_accessor :foobar
-        ^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        ^^^^^^^^^^^^^^^^^^^^^^ #{msg}
       end
     RUBY
   end
@@ -113,7 +114,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         cattr_writer :foobar
-        ^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        ^^^^^^^^^^^^^^^^^^^^ #{msg}
       end
     RUBY
   end
@@ -122,7 +123,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         cattr_accessor :foobar
-        ^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        ^^^^^^^^^^^^^^^^^^^^^^ #{msg}
       end
     RUBY
   end
@@ -131,7 +132,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         class_attribute :foobar
-        ^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+        ^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
       end
     RUBY
   end

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -3,90 +3,92 @@
 RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for `attr` in the singleton class' do
-    expect_offense(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr :foobar
-          ^^^^^^^^^^^^ Avoid mutating class and module attributes.
+  context 'when in the singleton class' do
+    it 'registers an offense for `attr`' do
+      expect_offense(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr :foobar
+            ^^^^^^^^^^^^ Avoid mutating class and module attributes.
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense for `attr_accessor` in the singleton class' do
-    expect_offense(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_accessor :foobar
-          ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+    it 'registers an offense for `attr_accessor`' do
+      expect_offense(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_accessor :foobar
+            ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense for `attr_writer` in the singleton class' do
-    expect_offense(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_writer :foobar
-          ^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+    it 'registers an offense for `attr_writer`' do
+      expect_offense(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_writer :foobar
+            ^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers no offense for `attr_reader` in the singleton class' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_reader :foobar
+    it 'registers no offense for `attr_reader`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_reader :foobar
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense for `attr_internal` in the singleton class' do
-    expect_offense(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_internal :foobar
-          ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+    it 'registers an offense for `attr_internal`' do
+      expect_offense(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_internal :foobar
+            ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense for `attr_internal_accessor` in the singleton class' do
-    expect_offense(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_internal_accessor :foobar
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+    it 'registers an offense for `attr_internal_accessor`' do
+      expect_offense(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_internal_accessor :foobar
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense for `attr_internal_writer` in the singleton class' do
-    expect_offense(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_internal_writer :foobar
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+    it 'registers an offense for `attr_internal_writer`' do
+      expect_offense(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_internal_writer :foobar
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers no offense for `attr_internal_reader` in the singleton class' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      module Test
-        class << self
-          attr_internal_reader :foobar
+    it 'registers no offense for `attr_internal_reader`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+          class << self
+            attr_internal_reader :foobar
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
   it 'registers an offense for `mattr_writer`' do


### PR DESCRIPTION
Detect `attr_internal` methods which are provided by activesupport as a wrapper to attr methods (with a leading underscore or configured naming format).