### PR TITLE
Add MutableClassInstanceVariable cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,12 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
 
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 14
+
 Naming/FileName:
   Exclude:
     - lib/rubocop-thread_safety.rb

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Scan the application for just thread-safety issues:
 
     $ rubocop -r rubocop-thread_safety --only ThreadSafety,Style/GlobalVars,Style/ClassVars,Style/MutableConstant
 
+### Configuration
+
+There are some added [configuration options](https://github.com/covermymeds/rubocop-thread_safety/blob/master/config/default.yml) that can be tweaked to modify the behaviour of these thread-safety cops.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,30 @@
+# Additional configuration for thread_safety cops
+#
+# Without adding these to your rubocop config, these values will be the default.
+
+ThreadSafety/ClassAndModuleAttributes:
+  Description: 'Avoid mutating class and module attributes.'
+  Enabled: true
+
+ThreadSafety/InstanceVariableInClassMethod:
+  Description: 'Avoid using instance variables in class methods.'
+  Enabled: true
+
+ThreadSafety/MutableClassInstanceVariable:
+  Description: 'Do not assign mutable objects to class instance variables.'
+  Enabled: true
+  EnforcedStyle: literals
+  SupportedStyles:
+    # literals: freeze literals assigned to constants
+    # strict: freeze all constants
+    # Strict mode is considered an experimental feature. It has not been updated
+    # with an exhaustive list of all methods that will produce frozen objects so
+    # there is a decent chance of getting some false positives. Luckily, there is
+    # no harm in freezing an already frozen object.
+    - literals
+    - strict
+
+ThreadSafety/NewThread:
+  Description: >-
+                 Avoid starting new threads.
+                 Let a framework like Sidekiq handle the threads.

--- a/lib/rubocop-thread_safety.rb
+++ b/lib/rubocop-thread_safety.rb
@@ -2,8 +2,13 @@
 
 require 'rubocop'
 
+require 'rubocop/thread_safety'
 require 'rubocop/thread_safety/version'
+require 'rubocop/thread_safety/inject'
+
+RuboCop::ThreadSafety::Inject.defaults!
 
 require 'rubocop/cop/thread_safety/instance_variable_in_class_method'
 require 'rubocop/cop/thread_safety/class_and_module_attributes'
+require 'rubocop/cop/thread_safety/mutable_class_instance_variable'
 require 'rubocop/cop/thread_safety/new_thread'

--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ThreadSafety
+      # This cop checks whether some class instance variable isn't a
+      # mutable literal (e.g. array or hash).
+      #
+      # It is based on Style/MutableConstant from RuboCop.
+      # See https://github.com/rubocop-hq/rubocop/blob/master/LICENSE.txt
+      #
+      # Class instance variables are a risk to threaded code as they are shared
+      # between threads. A mutable object such as an array or hash may be
+      # updated via an attr_reader so would not be detected by the
+      # ThreadSafety/ClassAndModuleAttributes cop.
+      #
+      # Strict mode can be used to freeze all class instance variables, rather
+      # than just literals.
+      # Strict mode is considered an experimental feature. It has not been
+      # updated with an exhaustive list of all methods that will produce frozen
+      # objects so there is a decent chance of getting some false positives.
+      # Luckily, there is no harm in freezing an already frozen object.
+      #
+      # @example EnforcedStyle: literals (default)
+      #   # bad
+      #   class Model
+      #     @list = [1, 2, 3]
+      #   end
+      #
+      #   # good
+      #   class Model
+      #     @list = [1, 2, 3].freeze
+      #   end
+      #
+      #   # good
+      #   class Model
+      #     @var = <<-TESTING.freeze
+      #       This is a heredoc
+      #     TESTING
+      #   end
+      #
+      #   # good
+      #   class Model
+      #     @var = Something.new
+      #   end
+      #
+      # @example EnforcedStyle: strict
+      #   # bad
+      #   class Model
+      #     @var = Something.new
+      #   end
+      #
+      #   # bad
+      #   class Model
+      #     @var = Struct.new do
+      #       def foo
+      #         puts 1
+      #       end
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Model
+      #     @var = Something.new.freeze
+      #   end
+      #
+      #   # good
+      #   class Model
+      #     @var = Struct.new do
+      #       def foo
+      #         puts 1
+      #       end
+      #     end.freeze
+      #   end
+      class MutableClassInstanceVariable < Cop
+        include FrozenStringLiteral
+        include ConfigurableEnforcedStyle
+
+        MSG = 'Freeze mutable objects assigned to class instance variables.'
+
+        def on_ivasgn(node)
+          return unless in_class?(node)
+
+          _, value = *node
+          on_assignment(value)
+        end
+
+        def on_or_asgn(node)
+          lhs, value = *node
+          return unless lhs&.ivasgn_type?
+          return unless in_class?(node)
+
+          on_assignment(value)
+        end
+
+        def on_masgn(node)
+          return unless in_class?(node)
+
+          mlhs, values = *node
+          return unless values.array_type?
+
+          mlhs.to_a.zip(values.to_a).each do |lhs, value|
+            next unless lhs.ivasgn_type?
+
+            on_assignment(value)
+          end
+        end
+
+        def autocorrect(node)
+          expr = node.source_range
+
+          lambda do |corrector|
+            splat_value = splat_value(node)
+            if splat_value
+              correct_splat_expansion(corrector, expr, splat_value)
+            elsif node.array_type? && !node.bracketed?
+              corrector.insert_before(expr, '[')
+              corrector.insert_after(expr, ']')
+            elsif requires_parentheses?(node)
+              corrector.insert_before(expr, '(')
+              corrector.insert_after(expr, ')')
+            end
+
+            corrector.insert_after(expr, '.freeze')
+          end
+        end
+
+        private
+
+        def on_assignment(value)
+          if style == :strict
+            strict_check(value)
+          else
+            check(value)
+          end
+        end
+
+        def strict_check(value)
+          return if immutable_literal?(value)
+          return if operation_produces_immutable_object?(value)
+          return if frozen_string_literal?(value)
+
+          add_offense(value)
+        end
+
+        def check(value)
+          return unless mutable_literal?(value) ||
+                        range_enclosed_in_parentheses?(value)
+          return if frozen_string_literal?(value)
+
+          add_offense(value)
+        end
+
+        def in_class?(node)
+          container = node.ancestors.find do |ancestor|
+            container?(ancestor)
+          end
+          return false if container.nil?
+
+          %i[class module].include?(container.type)
+        end
+
+        def container?(node)
+          return true if define_singleton_method?(node)
+
+          %i[def defs class module].include?(node.type)
+        end
+
+        def mutable_literal?(node)
+          node&.mutable_literal?
+        end
+
+        def immutable_literal?(node)
+          node.nil? || node.immutable_literal?
+        end
+
+        def frozen_string_literal?(node)
+          FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
+            frozen_string_literals_enabled?
+        end
+
+        def requires_parentheses?(node)
+          node.range_type? ||
+            (node.send_type? && node.loc.dot.nil?)
+        end
+
+        def correct_splat_expansion(corrector, expr, splat_value)
+          if range_enclosed_in_parentheses?(splat_value)
+            corrector.replace(expr, "#{splat_value.source}.to_a")
+          else
+            corrector.replace(expr, "(#{splat_value.source}).to_a")
+          end
+        end
+
+        def_node_matcher :define_singleton_method?, <<-PATTERN
+          (block (send nil? :define_singleton_method ...) ...)
+        PATTERN
+
+        def_node_matcher :splat_value, <<-PATTERN
+          (array (splat $_))
+        PATTERN
+
+        # NOTE: Some of these patterns may not actually return an immutable
+        # object but we will consider them immutable for this cop.
+        def_node_matcher :operation_produces_immutable_object?, <<-PATTERN
+          {
+            (const _ _)
+            (send (const nil? :Struct) :new ...)
+            (block (send (const nil? :Struct) :new ...) ...)
+            (send _ :freeze)
+            (send {float int} {:+ :- :* :** :/ :% :<<} _)
+            (send _ {:+ :- :* :** :/ :%} {float int})
+            (send _ {:== :=== :!= :<= :>= :< :>} _)
+            (send (const nil? :ENV) :[] _)
+            (or (send (const nil? :ENV) :[] _) _)
+            (send _ {:count :length :size} ...)
+            (block (send _ {:count :length :size} ...) ...)
+          }
+        PATTERN
+
+        def_node_matcher :range_enclosed_in_parentheses?, <<-PATTERN
+          (begin ({irange erange} _ _))
+        PATTERN
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -7,7 +7,7 @@ module RuboCop
       # mutable literal (e.g. array or hash).
       #
       # It is based on Style/MutableConstant from RuboCop.
-      # See https://github.com/rubocop-hq/rubocop/blob/master/LICENSE.txt
+      # See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/style/mutable_constant.rb
       #
       # Class instance variables are a risk to threaded code as they are shared
       # between threads. A mutable object such as an array or hash may be

--- a/lib/rubocop/thread_safety.rb
+++ b/lib/rubocop/thread_safety.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # RuboCop::ThreadSafety detects some potential thread safety issues.
+  module ThreadSafety
+    PROJECT_ROOT = Pathname.new(File.expand_path('../../', __dir__))
+    CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
+    CONFIG = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+
+    private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+  end
+end

--- a/lib/rubocop/thread_safety/inject.rb
+++ b/lib/rubocop/thread_safety/inject.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# The original code is from https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
+# See https://github.com/rubocop-hq/rubocop-rspec/blob/master/MIT_LICENSE.md
+module RuboCop
+  module ThreadSafety
+    # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+    # bit of our configuration.
+    module Inject
+      def self.defaults!
+        path = CONFIG_DEFAULT.to_s
+        hash = ConfigLoader.__send__(:load_yaml_configuration, path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
+        puts "configuration from \#{path}" if ConfigLoader.debug?
+        config = ConfigLoader.merge_with_default(config, path)
+        ConfigLoader.instance_variable_set(:@default_configuration, config)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -1,0 +1,629 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
+               :config do
+  subject(:cop) { described_class.new(config) }
+  let(:msg) { 'Freeze mutable objects assigned to class instance variables.' }
+
+  let(:prefix) { nil }
+  let(:suffix) { nil }
+  let(:indent) { '' }
+  def surround(code)
+    [
+      prefix,
+      code.split("\n").map { |line| "#{indent}#{line}" },
+      suffix
+    ].compact.join("\n")
+  end
+
+  shared_examples 'mutable objects' do |o|
+    context 'when assigning with =' do
+      it "registers an offense for #{o} assigned to a class ivar" do
+        expect_offense(surround(<<-RUBY.strip_indent))
+          @var = #{o}
+                 #{'^' * o.length} #{msg}
+        RUBY
+      end
+
+      it 'auto-corrects by adding .freeze' do
+        new_source = autocorrect_source(surround("@var = #{o}"))
+        expect(new_source).to eq(surround("@var = #{o}.freeze"))
+      end
+    end
+
+    context 'when assigning with ||=' do
+      it "registers an offense for #{o} assigned to a class ivar" do
+        expect_offense(surround(<<-RUBY.strip_indent))
+          @var ||= #{o}
+                   #{'^' * o.length} #{msg}
+        RUBY
+      end
+
+      it 'auto-corrects by adding .freeze' do
+        new_source = autocorrect_source(surround("@var ||= #{o}"))
+        expect(new_source).to eq(surround("@var ||= #{o}.freeze"))
+      end
+    end
+  end
+
+  shared_examples 'immutable objects' do |o|
+    it "allows #{o} to be assigned to a class ivar" do
+      expect_no_offenses(surround("@var = #{o}"))
+    end
+
+    it "allows #{o} to be ||= to a class ivar" do
+      expect_no_offenses(surround("@var ||= #{o}"))
+    end
+  end
+
+  context 'when not directly in class / module' do
+    context 'top level code' do
+      it_behaves_like 'immutable objects', '[1, 2, 3]'
+    end
+
+    context 'inside a method' do
+      let(:prefix) { "class Test\n  def some_method" }
+      let(:suffix) { "  end\nend" }
+      let(:indent) { '    ' }
+
+      it_behaves_like 'immutable objects', '{ a: 1, b: 2 }'
+    end
+
+    context 'inside a class method' do
+      let(:prefix) { "class Test\n  def self.some_method" }
+      let(:suffix) { "  end\nend" }
+      let(:indent) { '    ' }
+
+      it_behaves_like 'immutable objects', '%w(a b c)'
+    end
+
+    context 'inside a class singleton method' do
+      let(:prefix) do
+        <<-RUBY.strip_indent
+          class Test
+            class << self
+              def some_method
+        RUBY
+      end
+      let(:suffix) do
+        <<-RUBY.strip_indent
+              end
+            end
+          end
+        RUBY
+      end
+      let(:indent) { ' ' * 6 }
+
+      it_behaves_like 'immutable objects', '%i{a b c}'
+    end
+
+    context 'inside define_singleton_method' do
+      let(:prefix) { "class Test\n  define_singleton_method(:name) do" }
+      let(:suffix) { "  end\nend" }
+      let(:indent) { '    ' }
+
+      it_behaves_like 'immutable objects', '[1, 2]'
+    end
+  end
+
+  context 'Strict: false' do
+    let(:cop_config) { { 'EnforcedStyle' => 'literals' } }
+
+    %w[class module].each do |mod|
+      context "inside a #{mod}" do
+        let(:prefix) { "#{mod} Test" }
+        let(:suffix) { 'end' }
+        let(:indent) { '  ' }
+
+        it_behaves_like 'mutable objects', '[1, 2, 3]'
+        it_behaves_like 'mutable objects', '%w(a b c)'
+        it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
+        it_behaves_like 'mutable objects', "'str'"
+        it_behaves_like 'mutable objects', %("\#{30 + 12}nd")
+
+        it_behaves_like 'immutable objects', '1'
+        it_behaves_like 'immutable objects', '2.1'
+        it_behaves_like 'immutable objects', ':sym'
+        it_behaves_like 'immutable objects', 'CONST'
+        it_behaves_like 'immutable objects', 'FOO + BAR'
+        it_behaves_like 'immutable objects', 'FOO - BAR'
+        it_behaves_like 'immutable objects', "'foo' + BAR"
+        it_behaves_like 'immutable objects', "ENV['foo']"
+
+        it_behaves_like 'immutable objects', '[1, 2].freeze'
+        it_behaves_like 'immutable objects', 'Something.new'
+
+        it 'registers no offense for class variable' do
+          expect_no_offenses(surround('@@list = [1, 2]'))
+        end
+
+        context 'inside an if statement' do
+          let(:prefix) { "#{mod} Test\n  if something" }
+          let(:suffix) { "  end\nend" }
+          let(:indent) { '    ' }
+
+          it_behaves_like 'mutable objects', '[1, 2, 3]'
+        end
+
+        context 'splat expansion' do
+          context 'expansion of a range' do
+            it 'registers an offense' do
+              expect_offense(surround(<<-RUBY.strip_indent))
+                @var = *1..10
+                       ^^^^^^ #{msg}
+              RUBY
+            end
+
+            it 'corrects to use to_a.freeze' do
+              new_source = autocorrect_source(surround('@var = *1..10'))
+              expect(new_source).to eq(surround('@var = (1..10).to_a.freeze'))
+            end
+
+            context 'with parentheses' do
+              it 'registers an offense' do
+                expect_offense(surround(<<-RUBY.strip_indent))
+                  @var = *(1..10)
+                         ^^^^^^^^ #{msg}
+                RUBY
+              end
+
+              it 'corrects to use to_a.freeze' do
+                new_source = autocorrect_source(surround('@var = *(1..10)'))
+                expect(new_source).to eq(surround('@var = (1..10).to_a.freeze'))
+              end
+            end
+          end
+        end
+
+        context 'when assigning an array without brackets' do
+          it 'adds brackets when auto-correcting' do
+            new_source = autocorrect_source(surround('@var = YYY, ZZZ'))
+            expect(new_source).to eq(surround('@var = [YYY, ZZZ].freeze'))
+          end
+
+          it 'does not add brackets to %w() arrays' do
+            new_source = autocorrect_source(surround('@var = %w(YYY ZZZ)'))
+            expect(new_source).to eq(surround('@var = %w(YYY ZZZ).freeze'))
+          end
+        end
+
+        context 'when assigning a range (irange) without parentheses' do
+          it 'adds parentheses when auto-correcting' do
+            new_source = autocorrect_source(surround('@var = 1..99'))
+            expect(new_source).to eq(surround('@var = (1..99).freeze'))
+          end
+
+          it 'does not add parenetheses to range enclosed in parentheses' do
+            new_source = autocorrect_source(surround('@var = (1..99)'))
+            expect(new_source).to eq(surround('@var = (1..99).freeze'))
+          end
+        end
+
+        context 'when assigning a range (erange) without parentheses' do
+          it 'adds parentheses when auto-correcting' do
+            new_source = autocorrect_source(surround('@var = 1...99'))
+            expect(new_source).to eq(surround('@var = (1...99).freeze'))
+          end
+
+          it 'does not add parentheses to range enclosed in parentheses' do
+            new_source = autocorrect_source(surround('@var = (1...99)'))
+            expect(new_source).to eq(surround('@var = (1...99).freeze'))
+          end
+        end
+
+        context 'with a frozen string literal' do
+          # TODO: It is not yet decided when frozen string will be the default.
+          # It has been abandoned for Ruby 3.0 but may default in the future.
+          # So these tests are given a provisional value of 4.0.
+          if RuboCop::TargetRuby.supported_versions.include?(4.0)
+            context 'when the target ruby version >= 4.0' do
+              let(:ruby_version) { 4.0 }
+
+              context 'when the frozen_string_literal comment is missing' do
+                it_behaves_like 'immutable objects', %("\#{a}")
+              end
+
+              context 'when the frozen_string_literal_comment is true' do
+                let(:prefix) { "# frozen_string_literal: true\n#{super()}" }
+
+                it_behaves_like 'immutable objects', %("\#{a}")
+              end
+
+              context 'when the frozen_string_literal_comment is false' do
+                let(:prefix) { "# frozen_string_literal: false\n#{super()}" }
+
+                it_behaves_like 'immutable objects', %("\#{a}")
+              end
+            end
+          end
+
+          context 'when the frozen_string_literal comment is missing' do
+            it_behaves_like 'mutable objects', %("\#{a}")
+          end
+
+          context 'when the frozen_string_literal comment is true' do
+            let(:prefix) { "# frozen_string_literal: true\n#{super()}" }
+
+            it_behaves_like 'immutable objects', %("\#{a}")
+          end
+
+          context 'when the frozen_string_literal comment is false' do
+            let(:prefix) { "# frozen_string_literal: false\n#{super()}" }
+
+            it_behaves_like 'mutable objects', %("\#{a}")
+          end
+        end
+
+        context 'when assigning to multiple class ivars' do
+          it 'registers an offense when first object is mutable' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, @b = [1], 1
+                       ^^^ #{msg}
+            RUBY
+          end
+
+          it 'freezes first object when mutable' do
+            new_source = autocorrect_source(surround('@a, @b = [1], 1'))
+            expect(new_source).to eq(surround('@a, @b = [1].freeze, 1'))
+          end
+
+          it 'registers an offense when middle object is mutable' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = [1, { a: 1 }, [3].freeze]
+                               ^^^^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'frezees middle object when mutable' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = [1, { a: 1 }, [3].freeze]
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = [1, { a: 1 }.freeze, [3].freeze]
+            RUBY
+          end
+
+          it 'registers an offense when last object is mutable' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, _, @c = 1, [2].freeze, 'foo'
+                                         ^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'freezes last object when mutable' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a, _, @c = 1, [2].freeze, 'foo'
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a, _, @c = 1, [2].freeze, 'foo'.freeze
+            RUBY
+          end
+
+          it 'registers an offense for multiple mutable objects' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = 'foo', [2], 3
+                           ^^^^^ #{msg}
+                                  ^^^ #{msg}
+            RUBY
+          end
+
+          it 'freezes multiple mutable objects' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = ['foo', [2], 3]
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = ['foo'.freeze, [2].freeze, 3]
+            RUBY
+          end
+        end
+
+        it 'freezes a heredoc' do
+          new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            @var = <<-HERE
+              content
+            HERE
+          RUBY
+
+          expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            @var = <<-HERE.freeze
+              content
+            HERE
+          RUBY
+        end
+      end
+    end
+  end
+
+  context 'Strict: true' do
+    let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
+
+    %w[class module].each do |mod|
+      context "inside a #{mod}" do
+        let(:prefix) { "#{mod} Test" }
+        let(:suffix) { 'end' }
+        let(:indent) { '  ' }
+
+        it_behaves_like 'mutable objects', '[1, 2, 3]'
+        it_behaves_like 'mutable objects', '%w(a b c)'
+        it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
+        it_behaves_like 'mutable objects', "'str'"
+        it_behaves_like 'mutable objects', %("\#{30 + 12}nd")
+        it_behaves_like 'mutable objects', 'Something.new'
+
+        it_behaves_like 'immutable objects', '1'
+        it_behaves_like 'immutable objects', '2.1'
+        it_behaves_like 'immutable objects', ':sym'
+        it_behaves_like 'immutable objects', 'CONST'
+        it_behaves_like 'immutable objects', 'Namespace::CONST'
+        it_behaves_like 'immutable objects', 'Struct.new'
+        it_behaves_like 'immutable objects', 'Struct.new(:a, :b)'
+        it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+          Struct.new(:node) do
+            def assignment?
+              true
+            end
+          end
+        RUBY
+
+        it_behaves_like 'immutable objects', '[1, 2].freeze'
+        it_behaves_like 'immutable objects', 'Something.new.freeze'
+
+        it 'registers no offense for class variable' do
+          expect_no_offenses(surround('@@list = [1, 2]'))
+        end
+
+        context 'inside an if statement' do
+          let(:prefix) { "#{mod} Test\n  if something" }
+          let(:suffix) { "  end\nend" }
+          let(:indent) { '    ' }
+
+          it_behaves_like 'mutable objects', '[1, 2, 3]'
+        end
+
+        context 'splat expansion' do
+          context 'expansion of a range' do
+            it 'registers an offense' do
+              expect_offense(surround(<<-RUBY.strip_indent))
+                @var = *1..10
+                       ^^^^^^ #{msg}
+              RUBY
+            end
+
+            it 'corrects to use to_a.freeze' do
+              new_source = autocorrect_source(surround('@var = *1..10'))
+              expect(new_source).to eq(surround('@var = (1..10).to_a.freeze'))
+            end
+
+            context 'with parentheses' do
+              it 'registers an offense' do
+                expect_offense(surround(<<-RUBY.strip_indent))
+                  @var = *(1..10)
+                         ^^^^^^^^ #{msg}
+                RUBY
+              end
+
+              it 'corrects to use to_a.freeze' do
+                new_source = autocorrect_source(surround('@var = *(1..10)'))
+                expect(new_source).to eq(surround('@var = (1..10).to_a.freeze'))
+              end
+            end
+          end
+        end
+
+        context 'when assigning with an operator' do
+          shared_examples 'operator methods' do |o|
+            it 'registers an offense' do
+              c = '^' * o.length
+              expect_offense(surround(<<-RUBY.strip_indent))
+                @var = FOO #{o} BAR
+                       ^^^^#{c}^^^^ #{msg}
+              RUBY
+            end
+
+            it 'auto-corrects by adding .freeze' do
+              new_source = autocorrect_source(surround("@var = FOO #{o} BAR"))
+              expect(new_source).to eq(surround("@var = (FOO #{o} BAR).freeze"))
+            end
+          end
+
+          it_behaves_like 'operator methods', '+'
+          it_behaves_like 'operator methods', '-'
+          it_behaves_like 'operator methods', '*'
+          it_behaves_like 'operator methods', '/'
+          it_behaves_like 'operator methods', '%'
+          it_behaves_like 'operator methods', '**'
+        end
+
+        context 'when assigning with multiple operator calls' do
+          it 'registers an offense' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a = [1].freeze
+              @b = [2].freeze
+              @c = [3].freeze
+              @var = @a + @b + @c
+                     ^^^^^^^^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'corrects by wrapping in parentheses and freezing' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a = [1].freeze
+              @b = [2].freeze
+              @c = [3].freeze
+              @var = @a + @b + @c
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a = [1].freeze
+              @b = [2].freeze
+              @c = [3].freeze
+              @var = (@a + @b + @c).freeze
+            RUBY
+          end
+        end
+
+        context 'methods and operators that produce frozen objects' do
+          it_behaves_like 'immutable objects', "ENV['foo'] || 'bar'"
+          it_behaves_like 'immutable objects', 'FOO + 2'
+          it_behaves_like 'immutable objects', '1 + 2'
+          it_behaves_like 'immutable objects', 'FOO + 2.1'
+          it_behaves_like 'immutable objects', '1.2 + 3.4'
+          it_behaves_like 'immutable objects', 'FOO == BAR'
+
+          describe 'checking fixed size' do
+            it_behaves_like 'immutable objects', "'foo'.count"
+            it_behaves_like 'immutable objects', "'foo'.count('f')"
+            it_behaves_like 'immutable objects', '[1, 2, 3].count { |n| n > 2 }'
+            it_behaves_like 'immutable objects', '[1, 2].count(2) { |n| n > 2 }'
+            it_behaves_like 'immutable objects', "'foo'.length"
+            it_behaves_like 'immutable objects', "'foo'.size"
+          end
+        end
+
+        context 'operators that produce unfrozen objects' do
+          it 'registers an offense when operating on a constant and a string' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @var = FOO + 'bar'
+                     ^^^^^^^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'autocorrects with parentheses' do
+            new_source = autocorrect_source(surround("@var = FOO + 'bar'"))
+            expect(new_source).to eq(surround("@var = (FOO + 'bar').freeze"))
+          end
+
+          it 'registers an offense when operating on multiple strings' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @var = 'foo' + 'bar' + 'baz'
+                     ^^^^^^^^^^^^^^^^^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'autocorrects with parentheses' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @var = 'foo' + 'bar' + 'baz'
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @var = ('foo' + 'bar' + 'baz').freeze
+            RUBY
+          end
+        end
+
+        context 'when assigning an array without brackets' do
+          it 'adds brackets when auto-correcting' do
+            new_source = autocorrect_source(surround('@var = @a, @b'))
+            expect(new_source).to eq(surround('@var = [@a, @b].freeze'))
+          end
+
+          it 'does not add brackets to %w() arrays' do
+            new_source = autocorrect_source(surround('@var = %w(YYY ZZZ)'))
+            expect(new_source).to eq(surround('@var = %w(YYY ZZZ).freeze'))
+          end
+        end
+
+        it 'freezes a heredoc' do
+          new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            @var = <<-HERE
+              content
+            HERE
+          RUBY
+
+          expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            @var = <<-HERE.freeze
+              content
+            HERE
+          RUBY
+        end
+
+        context 'with a frozen string literal' do
+          context 'when the frozen_string_literal comment is missing' do
+            it_behaves_like 'mutable objects', %("\#{a}")
+          end
+
+          context 'when the frozen_string_literal comment is true' do
+            let(:prefix) { "# frozen_string_literal: true\n#{super()}" }
+
+            it_behaves_like 'immutable objects', %("\#{a}")
+          end
+
+          context 'when the frozen_string_literal comment is false' do
+            let(:prefix) { "# frozen_string_literal: false\n#{super()}" }
+
+            it_behaves_like 'mutable objects', %("\#{a}")
+          end
+        end
+
+        context 'when assigning to multiple class ivars' do
+          it 'registers an offense when first object is mutable' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, @b = [1], 1
+                       ^^^ #{msg}
+            RUBY
+          end
+
+          it 'freezes first object when mutable' do
+            new_source = autocorrect_source(surround('@a, @b = [1], 1'))
+            expect(new_source).to eq(surround('@a, @b = [1].freeze, 1'))
+          end
+
+          it 'registers an offense when middle object is mutable' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = [1, { a: 1 }, [3].freeze]
+                               ^^^^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'frezees middle object when mutable' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = [1, { a: 1 }, [3].freeze]
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = [1, { a: 1 }.freeze, [3].freeze]
+            RUBY
+          end
+
+          it 'registers an offense when last object is mutable' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, _, @c = 1, [2].freeze, 'foo'
+                                         ^^^^^ #{msg}
+            RUBY
+          end
+
+          it 'freezes last object when mutable' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a, _, @c = 1, [2].freeze, 'foo'
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a, _, @c = 1, [2].freeze, 'foo'.freeze
+            RUBY
+          end
+
+          it 'registers an offense for multiple mutable objects' do
+            expect_offense(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = 'foo', [2], 3
+                           ^^^^^ #{msg}
+                                  ^^^ #{msg}
+            RUBY
+          end
+
+          it 'freezes multiple mutable objects' do
+            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = ['foo', [2], 3]
+            RUBY
+
+            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+              @a, @b, @c = ['foo'.freeze, [2].freeze, 3]
+            RUBY
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cop for #19 - Enforce frozen class instance variables

Detect mutable objects assigned to class instance variable in class definition (not inside methods).

Implementation borrowed from RuboCop `Style/MutableConstant`.

Detect multiple assign to class ivar: `@a, @b = [1], 'foo'`. This is a common pattern in initializers but not sure yet if it is prevalent in class definitions.

Add config for MutableClassInstanceVariable EnforcedStyle. The default is `literals` as per `Style/MutableConstant` cop. Added config injection borrowed from [rubocop-extension-generator](https://github.com/rubocop-hq/rubocop-extension-generator).