### PR TITLE
Add known thread-safe objects to class ivar cop

### DIFF
--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -206,14 +206,14 @@ module RuboCop
         def_node_matcher :operation_produces_immutable_object?, <<-PATTERN
           {
             (const _ _)
-            (send (const nil? :Struct) :new ...)
-            (block (send (const nil? :Struct) :new ...) ...)
+            (send (const {nil? cbase} :Struct) :new ...)
+            (block (send (const {nil? cbase} :Struct) :new ...) ...)
             (send _ :freeze)
             (send {float int} {:+ :- :* :** :/ :% :<<} _)
             (send _ {:+ :- :* :** :/ :%} {float int})
             (send _ {:== :=== :!= :<= :>= :< :>} _)
-            (send (const nil? :ENV) :[] _)
-            (or (send (const nil? :ENV) :[] _) _)
+            (send (const {nil? cbase} :ENV) :[] _)
+            (or (send (const {nil? cbase} :ENV) :[] _) _)
             (send _ {:count :length :size} ...)
             (block (send _ {:count :length :size} ...) ...)
           }

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -14,7 +14,7 @@ module RuboCop
         MSG = 'Avoid starting new threads.'
 
         def_node_matcher :new_thread?, <<-MATCHER
-          (send (const nil? :Thread) :new)
+          (send (const {nil? cbase} :Thread) :new)
         MATCHER
 
         def on_send(node)

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -357,11 +357,22 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         it_behaves_like 'immutable objects', '2.1'
         it_behaves_like 'immutable objects', ':sym'
         it_behaves_like 'immutable objects', 'CONST'
+        it_behaves_like 'immutable objects', '::CONST'
         it_behaves_like 'immutable objects', 'Namespace::CONST'
+        it_behaves_like 'immutable objects', '::Namespace::CONST'
         it_behaves_like 'immutable objects', 'Struct.new'
+        it_behaves_like 'immutable objects', '::Struct.new'
         it_behaves_like 'immutable objects', 'Struct.new(:a, :b)'
+        it_behaves_like 'immutable objects', '::Struct.new(:a, :b)'
         it_behaves_like 'immutable objects', <<-RUBY.strip_indent
           Struct.new(:node) do
+            def assignment?
+              true
+            end
+          end
+        RUBY
+        it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+          ::Struct.new(:node) do
             def assignment?
               true
             end
@@ -370,6 +381,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         it_behaves_like 'immutable objects', '[1, 2].freeze'
         it_behaves_like 'immutable objects', 'Something.new.freeze'
+        it_behaves_like 'immutable objects', '::Something.new.freeze'
 
         context 'with thread-safe data structure' do
           it_behaves_like 'immutable objects', 'Queue.new'

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -371,6 +371,38 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         it_behaves_like 'immutable objects', '[1, 2].freeze'
         it_behaves_like 'immutable objects', 'Something.new.freeze'
 
+        context 'with thread-safe data structure' do
+          it_behaves_like 'immutable objects', 'Queue.new'
+          it_behaves_like 'immutable objects', '::Queue.new'
+          it_behaves_like 'immutable objects', 'ThreadSafe::Array.new'
+          it_behaves_like 'immutable objects', '::ThreadSafe::Hash.new'
+          it_behaves_like 'immutable objects', 'ThreadSafe::Hash.new { false }'
+          it_behaves_like 'immutable objects', 'Concurrent::Array.new'
+          it_behaves_like 'immutable objects', 'Concurrent::Hash.new'
+          it_behaves_like 'immutable objects', '::Concurrent::Map.new'
+          it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+            Concurrent::Map.new(initial_capacity: 4)
+          RUBY
+          it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+            Concurrent::Map.new do |h, key|
+              h.fetch_or_store(key, Concurrent::Map.new)
+            end
+          RUBY
+          it_behaves_like 'immutable objects',
+                          'Concurrent::ContinuationQueue.new'
+          it_behaves_like 'immutable objects',
+                          'Concurrent::ThreadPoolExecutor.new(options)'
+          it_behaves_like 'immutable objects',
+                          'Concurrent::AtomicBoolean.new(true)'
+          it_behaves_like 'immutable objects',
+                          'Concurrent::ThreadSafe::Util::Adder.new'
+
+          it_behaves_like 'mutable objects', '[Queue.new]'
+          it_behaves_like 'mutable objects', '[ThreadSafe::Hash.new { false }]'
+          it_behaves_like 'mutable objects',
+                          '[Concurrent::ThreadSafe::Util::Adder.new]'
+        end
+
         it 'registers no offense for class variable' do
           expect_no_offenses(surround('@@list = [1, 2]'))
         end

--- a/spec/rubocop/cop/thread_safety/new_thread_spec.rb
+++ b/spec/rubocop/cop/thread_safety/new_thread_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe RuboCop::Cop::ThreadSafety::NewThread do
     RUBY
   end
 
+  it 'registers an offense for starting a new thread with top-level constant' do
+    expect_offense(<<-RUBY.strip_indent)
+      ::Thread.new { do_work }
+      ^^^^^^^^^^^^ Avoid starting new threads.
+    RUBY
+  end
+
   it 'does not register an offense for calling new on other classes' do
     expect_no_offenses('Other.new { do_work }')
   end


### PR DESCRIPTION
Further fixes #19

In `EnforceStyle: strict` mode, allow known thread-safe objects:

* `Queue`
* `ThreadSafe::Array`, `ThreadSafe::Hash` - deprecated gem `thread_safe` has been superseded by `concurrent-ruby` but old code may still use it.
* Data structures and other objects provided by `concurrent-ruby` gem, e.g.:
  * `Concurrent::Array`, `Concurrent::Map`
  * `Concurrent::Event`
  * `Concurrent::ContinuationQueue`
  * `Concurrent::ThreadPoolExecutor`
  * `Concurrent::AtomicBoolean`
  * `Concurrent::ThreadSafe::Util::Adder`

In adding these, it was noticed that top-level const like `::Queue` also needed matching. This changed has been applied to other matchers in `MutableClassInstanceVariable` and `NewThread` cops.