### PR TITLE
Fix Concurrent::* pattern for rubocop < 0.80.0

### DIFF
--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -230,9 +230,23 @@ module RuboCop
                 (const (const {nil? cbase} :ThreadSafe) {:Hash :Array})
                 :new ...)
               ...)
-            (send (const `(const {nil? cbase} :Concurrent) _) :new ...)
+            (send (const (const {nil? cbase} :Concurrent) _) :new ...)
             (block
-              (send (const `(const {nil? cbase} :Concurrent) _) :new ...)
+              (send (const (const {nil? cbase} :Concurrent) _) :new ...)
+              ...)
+            (send (const (const (const {nil? cbase} :Concurrent) _) _) :new ...)
+            (block
+              (send
+                (const (const (const {nil? cbase} :Concurrent) _) _)
+                :new ...)
+              ...)
+            (send
+              (const (const (const (const {nil? cbase} :Concurrent) _) _) _)
+              :new ...)
+            (block
+              (send
+                (const (const (const (const {nil? cbase} :Concurrent) _) _) _)
+                :new ...)
               ...)
           }
         PATTERN


### PR DESCRIPTION
[rubocop 0.80.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0800-2020-02-18) added ` for descendant search.

Expand pattern in `MutableClassInstanceVariable` for 2, 3, 4 levels deep
classes/modules under `Concurrent` namespace.