### PR TITLE
Remove powerpack and use squiggly heredocs

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -15,25 +15,25 @@ module RuboCop
       class ClassAndModuleAttributes < Cop
         MSG = 'Avoid mutating class and module attributes.'
 
-        def_node_matcher :mattr?, <<-MATCHER
+        def_node_matcher :mattr?, <<~MATCHER
           (send nil?
             {:mattr_writer :mattr_accessor :cattr_writer :cattr_accessor}
             ...)
         MATCHER
 
-        def_node_matcher :attr?, <<-MATCHER
+        def_node_matcher :attr?, <<~MATCHER
           (send nil?
             {:attr :attr_accessor :attr_writer}
             ...)
         MATCHER
 
-        def_node_matcher :attr_internal?, <<-MATCHER
+        def_node_matcher :attr_internal?, <<~MATCHER
           (send nil?
             {:attr_internal :attr_internal_accessor :attr_internal_writer}
             ...)
         MATCHER
 
-        def_node_matcher :class_attr?, <<-MATCHER
+        def_node_matcher :class_attr?, <<~MATCHER
           (send nil?
             :class_attribute
             ...)

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -40,11 +40,11 @@ module RuboCop
       class InstanceVariableInClassMethod < Cop
         MSG = 'Avoid instance variables in class methods.'
 
-        def_node_matcher :instance_variable_set_call?, <<-MATCHER
+        def_node_matcher :instance_variable_set_call?, <<~MATCHER
           (send nil? :instance_variable_set (...) (...))
         MATCHER
 
-        def_node_matcher :instance_variable_get_call?, <<-MATCHER
+        def_node_matcher :instance_variable_get_call?, <<~MATCHER
           (send nil? :instance_variable_get (...))
         MATCHER
 
@@ -122,7 +122,7 @@ module RuboCop
           instance_variable_set_call?(node) || instance_variable_get_call?(node)
         end
 
-        def_node_matcher :class_methods_module?, <<-PATTERN
+        def_node_matcher :class_methods_module?, <<~PATTERN
           (module (const _ :ClassMethods) ...)
         PATTERN
       end

--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -34,7 +34,7 @@ module RuboCop
       #
       #   # good
       #   class Model
-      #     @var = <<-TESTING.freeze
+      #     @var = <<~TESTING.freeze
       #       This is a heredoc
       #     TESTING
       #   end
@@ -199,17 +199,17 @@ module RuboCop
           end
         end
 
-        def_node_matcher :define_singleton_method?, <<-PATTERN
+        def_node_matcher :define_singleton_method?, <<~PATTERN
           (block (send nil? :define_singleton_method ...) ...)
         PATTERN
 
-        def_node_matcher :splat_value, <<-PATTERN
+        def_node_matcher :splat_value, <<~PATTERN
           (array (splat $_))
         PATTERN
 
         # NOTE: Some of these patterns may not actually return an immutable
         # object but we will consider them immutable for this cop.
-        def_node_matcher :operation_produces_immutable_object?, <<-PATTERN
+        def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
           {
             (const _ _)
             (send (const {nil? cbase} :Struct) :new ...)
@@ -225,7 +225,7 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :operation_produces_threadsafe_object?, <<-PATTERN
+        def_node_matcher :operation_produces_threadsafe_object?, <<~PATTERN
           {
             (send (const {nil? cbase} :Queue) :new ...)
             (send
@@ -257,7 +257,7 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :range_enclosed_in_parentheses?, <<-PATTERN
+        def_node_matcher :range_enclosed_in_parentheses?, <<~PATTERN
           (begin ({irange erange} _ _))
         PATTERN
       end

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -13,7 +13,7 @@ module RuboCop
       class NewThread < Cop
         MSG = 'Avoid starting new threads.'
 
-        def_node_matcher :new_thread?, <<-MATCHER
+        def_node_matcher :new_thread?, <<~MATCHER
           (send (const {nil? cbase} :Thread) :new)
         MATCHER
 

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
-  spec.add_development_dependency 'powerpack', '~> 0.1'
   spec.add_development_dependency 'pry' unless ENV['CI']
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
 
   context 'when in the singleton class' do
     it 'registers an offense for `attr`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         module Test
           class << self
             attr :foobar
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers an offense for `attr_accessor`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         module Test
           class << self
             attr_accessor :foobar
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers an offense for `attr_writer`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         module Test
           class << self
             attr_writer :foobar
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers no offense for `attr_reader`' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         module Test
           class << self
             attr_reader :foobar
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers an offense for `attr_internal`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         module Test
           class << self
             attr_internal :foobar
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers an offense for `attr_internal_accessor`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         module Test
           class << self
             attr_internal_accessor :foobar
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers an offense for `attr_internal_writer`' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         module Test
           class << self
             attr_internal_writer :foobar
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
     end
 
     it 'registers no offense for `attr_internal_reader`' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         module Test
           class << self
             attr_internal_reader :foobar
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   end
 
   it 'registers an offense for `mattr_writer`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       module Test
         mattr_writer :foobar
         ^^^^^^^^^^^^^^^^^^^^ #{msg}
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   end
 
   it 'registers an offense for `mattr_accessor`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       module Test
         mattr_accessor :foobar
         ^^^^^^^^^^^^^^^^^^^^^^ #{msg}
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   end
 
   it 'registers an offense for `cattr_writer`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         cattr_writer :foobar
         ^^^^^^^^^^^^^^^^^^^^ #{msg}
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   end
 
   it 'registers an offense for `cattr_accessor`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         cattr_accessor :foobar
         ^^^^^^^^^^^^^^^^^^^^^^ #{msg}
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   end
 
   it 'registers an offense for `class_attribute`' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         class_attribute :foobar
         ^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
   end
 
   it 'registers no offense for other class macro calls' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         belongs_to :foobar
       end

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for assigning to an ivar in a class method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         def self.some_method(params)
           @params = params
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense when the assignment is synchronized by a mutex' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         SEMAPHORE = Mutex.new
         def self.some_method(params)
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense when memoization is synchronized by a mutex' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         SEMAPHORE = Mutex.new
         def self.types
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for reading an ivar in a class method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         def self.some_method
           do_work(@params)
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for assigning an ivar in module ClassMethods' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       module ClassMethods
         def some_method(params)
           @params = params
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for assigning an ivar in a class singleton method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         class << self
           def some_method(params)
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for assigning an ivar in define_singleton_method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         define_singleton_method(:some_method) do |params|
           @params = params
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for ivar_get in a class method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         def self.some_method
           do_work(instance_variable_get(:@params))
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for ivar_set in a class singleton method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         class << self
           def some_method(name, params)
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for ivar_set in module ClassMethods' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       module ClassMethods
         def some_method(params)
           instance_variable_set(:@params, params)
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers an offense for ivar_set in define_singleton_method' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       class Test
         define_singleton_method(:some_method) do |params|
           instance_variable_set(:@params, params)
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense for using ivar_get on object in a class method' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         def self.some_method(obj, params)
           obj.instance_variable_get(:@params)
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense for using ivar_set on object in a class method' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         class << self
           def some_method(obj, params)
@@ -154,7 +154,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense for using an ivar in an instance method' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         def some_method(params)
           @params = params
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense for using ivar methods in an instance method' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       class Test
         def some_method(params)
           instance_variable_set(:@params, params)
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
   end
 
   it 'registers no offense for using an ivar in a module below ClassMethods' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       module ClassMethods
         module Other
           def some_method(params)

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
   shared_examples 'mutable objects' do |o|
     context 'when assigning with =' do
       it "registers an offense for #{o} assigned to a class ivar" do
-        expect_offense(surround(<<-RUBY.strip_indent))
+        expect_offense(surround(<<~RUBY))
           @var = #{o}
                  #{'^' * o.length} #{msg}
         RUBY
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
     context 'when assigning with ||=' do
       it "registers an offense for #{o} assigned to a class ivar" do
-        expect_offense(surround(<<-RUBY.strip_indent))
+        expect_offense(surround(<<~RUBY))
           @var ||= #{o}
                    #{'^' * o.length} #{msg}
         RUBY
@@ -83,14 +83,14 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
     context 'inside a class singleton method' do
       let(:prefix) do
-        <<-RUBY.strip_indent
+        <<~RUBY
           class Test
             class << self
               def some_method
         RUBY
       end
       let(:suffix) do
-        <<-RUBY.strip_indent
+        <<~RUBY
               end
             end
           end
@@ -152,7 +152,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         context 'splat expansion' do
           context 'expansion of a range' do
             it 'registers an offense' do
-              expect_offense(surround(<<-RUBY.strip_indent))
+              expect_offense(surround(<<~RUBY))
                 @var = *1..10
                        ^^^^^^ #{msg}
               RUBY
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
             context 'with parentheses' do
               it 'registers an offense' do
-                expect_offense(surround(<<-RUBY.strip_indent))
+                expect_offense(surround(<<~RUBY))
                   @var = *(1..10)
                          ^^^^^^^^ #{msg}
                 RUBY
@@ -261,7 +261,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         context 'when assigning to multiple class ivars' do
           it 'registers an offense when first object is mutable' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, @b = [1], 1
                        ^^^ #{msg}
             RUBY
@@ -273,41 +273,41 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           end
 
           it 'registers an offense when middle object is mutable' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, @b, @c = [1, { a: 1 }, [3].freeze]
                                ^^^^^^^^ #{msg}
             RUBY
           end
 
           it 'frezees middle object when mutable' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a, @b, @c = [1, { a: 1 }, [3].freeze]
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a, @b, @c = [1, { a: 1 }.freeze, [3].freeze]
             RUBY
           end
 
           it 'registers an offense when last object is mutable' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, _, @c = 1, [2].freeze, 'foo'
                                          ^^^^^ #{msg}
             RUBY
           end
 
           it 'freezes last object when mutable' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a, _, @c = 1, [2].freeze, 'foo'
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a, _, @c = 1, [2].freeze, 'foo'.freeze
             RUBY
           end
 
           it 'registers an offense for multiple mutable objects' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, @b, @c = 'foo', [2], 3
                            ^^^^^ #{msg}
                                   ^^^ #{msg}
@@ -315,24 +315,24 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           end
 
           it 'freezes multiple mutable objects' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a, @b, @c = ['foo', [2], 3]
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a, @b, @c = ['foo'.freeze, [2].freeze, 3]
             RUBY
           end
         end
 
         it 'freezes a heredoc' do
-          new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+          new_source = autocorrect_source(surround(<<~RUBY))
             @var = <<-HERE
               content
             HERE
           RUBY
 
-          expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+          expect(new_source).to eq(surround(<<~RUBY))
             @var = <<-HERE.freeze
               content
             HERE
@@ -369,14 +369,14 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         it_behaves_like 'immutable objects', '::Struct.new'
         it_behaves_like 'immutable objects', 'Struct.new(:a, :b)'
         it_behaves_like 'immutable objects', '::Struct.new(:a, :b)'
-        it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+        it_behaves_like 'immutable objects', <<~RUBY
           Struct.new(:node) do
             def assignment?
               true
             end
           end
         RUBY
-        it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+        it_behaves_like 'immutable objects', <<~RUBY
           ::Struct.new(:node) do
             def assignment?
               true
@@ -397,10 +397,10 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           it_behaves_like 'immutable objects', 'Concurrent::Array.new'
           it_behaves_like 'immutable objects', 'Concurrent::Hash.new'
           it_behaves_like 'immutable objects', '::Concurrent::Map.new'
-          it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+          it_behaves_like 'immutable objects', <<~RUBY
             Concurrent::Map.new(initial_capacity: 4)
           RUBY
-          it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+          it_behaves_like 'immutable objects', <<~RUBY
             Concurrent::Map.new do |h, key|
               h.fetch_or_store(key, Concurrent::Map.new)
             end
@@ -435,7 +435,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         context 'splat expansion' do
           context 'expansion of a range' do
             it 'registers an offense' do
-              expect_offense(surround(<<-RUBY.strip_indent))
+              expect_offense(surround(<<~RUBY))
                 @var = *1..10
                        ^^^^^^ #{msg}
               RUBY
@@ -448,7 +448,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
             context 'with parentheses' do
               it 'registers an offense' do
-                expect_offense(surround(<<-RUBY.strip_indent))
+                expect_offense(surround(<<~RUBY))
                   @var = *(1..10)
                          ^^^^^^^^ #{msg}
                 RUBY
@@ -466,7 +466,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           shared_examples 'operator methods' do |o|
             it 'registers an offense' do
               c = '^' * o.length
-              expect_offense(surround(<<-RUBY.strip_indent))
+              expect_offense(surround(<<~RUBY))
                 @var = FOO #{o} BAR
                        ^^^^#{c}^^^^ #{msg}
               RUBY
@@ -488,7 +488,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         context 'when assigning with multiple operator calls' do
           it 'registers an offense' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a = [1].freeze
               @b = [2].freeze
               @c = [3].freeze
@@ -498,14 +498,14 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           end
 
           it 'corrects by wrapping in parentheses and freezing' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a = [1].freeze
               @b = [2].freeze
               @c = [3].freeze
               @var = @a + @b + @c
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a = [1].freeze
               @b = [2].freeze
               @c = [3].freeze
@@ -534,7 +534,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         context 'operators that produce unfrozen objects' do
           it 'registers an offense when operating on a constant and a string' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @var = FOO + 'bar'
                      ^^^^^^^^^^^ #{msg}
             RUBY
@@ -546,18 +546,18 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           end
 
           it 'registers an offense when operating on multiple strings' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @var = 'foo' + 'bar' + 'baz'
                      ^^^^^^^^^^^^^^^^^^^^^ #{msg}
             RUBY
           end
 
           it 'autocorrects with parentheses' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @var = 'foo' + 'bar' + 'baz'
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @var = ('foo' + 'bar' + 'baz').freeze
             RUBY
           end
@@ -576,13 +576,13 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         end
 
         it 'freezes a heredoc' do
-          new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+          new_source = autocorrect_source(surround(<<~RUBY))
             @var = <<-HERE
               content
             HERE
           RUBY
 
-          expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+          expect(new_source).to eq(surround(<<~RUBY))
             @var = <<-HERE.freeze
               content
             HERE
@@ -609,7 +609,7 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         context 'when assigning to multiple class ivars' do
           it 'registers an offense when first object is mutable' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, @b = [1], 1
                        ^^^ #{msg}
             RUBY
@@ -621,41 +621,41 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           end
 
           it 'registers an offense when middle object is mutable' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, @b, @c = [1, { a: 1 }, [3].freeze]
                                ^^^^^^^^ #{msg}
             RUBY
           end
 
           it 'frezees middle object when mutable' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a, @b, @c = [1, { a: 1 }, [3].freeze]
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a, @b, @c = [1, { a: 1 }.freeze, [3].freeze]
             RUBY
           end
 
           it 'registers an offense when last object is mutable' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, _, @c = 1, [2].freeze, 'foo'
                                          ^^^^^ #{msg}
             RUBY
           end
 
           it 'freezes last object when mutable' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a, _, @c = 1, [2].freeze, 'foo'
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a, _, @c = 1, [2].freeze, 'foo'.freeze
             RUBY
           end
 
           it 'registers an offense for multiple mutable objects' do
-            expect_offense(surround(<<-RUBY.strip_indent))
+            expect_offense(surround(<<~RUBY))
               @a, @b, @c = 'foo', [2], 3
                            ^^^^^ #{msg}
                                   ^^^ #{msg}
@@ -663,11 +663,11 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
           end
 
           it 'freezes multiple mutable objects' do
-            new_source = autocorrect_source(surround(<<-RUBY.strip_indent))
+            new_source = autocorrect_source(surround(<<~RUBY))
               @a, @b, @c = ['foo', [2], 3]
             RUBY
 
-            expect(new_source).to eq(surround(<<-RUBY.strip_indent))
+            expect(new_source).to eq(surround(<<~RUBY))
               @a, @b, @c = ['foo'.freeze, [2].freeze, 3]
             RUBY
           end

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -327,13 +327,13 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         it 'freezes a heredoc' do
           new_source = autocorrect_source(surround(<<~RUBY))
-            @var = <<-HERE
+            @var = <<~HERE
               content
             HERE
           RUBY
 
           expect(new_source).to eq(surround(<<~RUBY))
-            @var = <<-HERE.freeze
+            @var = <<~HERE.freeze
               content
             HERE
           RUBY
@@ -577,13 +577,13 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
         it 'freezes a heredoc' do
           new_source = autocorrect_source(surround(<<~RUBY))
-            @var = <<-HERE
+            @var = <<~HERE
               content
             HERE
           RUBY
 
           expect(new_source).to eq(surround(<<~RUBY))
-            @var = <<-HERE.freeze
+            @var = <<~HERE.freeze
               content
             HERE
           RUBY

--- a/spec/rubocop/cop/thread_safety/new_thread_spec.rb
+++ b/spec/rubocop/cop/thread_safety/new_thread_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe RuboCop::Cop::ThreadSafety::NewThread do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for starting a new thread' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       Thread.new { do_work }
       ^^^^^^^^^^ Avoid starting new threads.
     RUBY
   end
 
   it 'registers an offense for starting a new thread with top-level constant' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       ::Thread.new { do_work }
       ^^^^^^^^^^^^ Avoid starting new threads.
     RUBY

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ end
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'rubocop-thread_safety'
 
-require 'powerpack/string/strip_indent'
 require 'rubocop/rspec/support'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Squiggly heredoc syntax `<<~` was introduced in ruby 2.3 to strip indentation equal to the least indented line.

This means we no longer need `.strip_indent` from powerpack gem.