### PR TITLE
Fix false-positive for attr accessors in singleton class methods

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -50,7 +50,19 @@ module RuboCop
 
         def singleton_attr?(node)
           (attr?(node) || attr_internal?(node)) &&
-            node.ancestors.map(&:type).include?(:sclass)
+            defined_in_singleton_class?(node)
+        end
+
+        def defined_in_singleton_class?(node)
+          node.ancestors.each do |ancestor|
+            case ancestor.type
+            when :def then return false
+            when :sclass then return true
+            else next
+            end
+          end
+
+          false
         end
       end
     end

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes do
         end
       RUBY
     end
+
+    context 'when in a singleton class method' do
+      it 'registers no offense for `attr_accessor`' do
+        expect_no_offenses(<<~RUBY)
+          module Test
+            class << self
+              def add_foobar_attr
+                attr_accessor :foobar
+              end
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   it 'registers an offense for `mattr_writer`' do


### PR DESCRIPTION
Hi - thanks very much for this gem, it's proven really helpful while preparing our rails app for a migration to puma! We noticed what we think is a false positive today, which this PR addresses.

The cop for class and module attributes works by checking an `attr_*` node's ancestors for a singleton class node. However, it doesn't account for accessors defined within a singleton class method, and produces a warning:

    class Test
      class << self
        def add_foobar_attr
          attr_accessor :foobar
          ^^^^^^^^^^^^^^^^^^^^^ Avoid mutating class and module attributes.
        end
      end
    end

This `attr_accessor` call produces instance-level reader and writer methods, and therefore isn't likely to be a thread-safety issue, so we think it shouldn't produce a warning. Defined another way, no warning is currently produced:

    class Test
      def self.add_foobar_attr
        attr_accessor :foobar
      end
    end

This change fixes the false positive by stepping up through the node's ancestors, and only record a violation if a singleton class node is found before any method definition node.

### Feedback

Any and all feedback would be very welcome, but my main questions are:

* Do you agree that this is a false positive and should be removed?
* Is it likely that I've introduced false negatives in some other scenario with this change?
* I've not exhaustively tested all the `attr_*` types since the fix applies to them all; does this seem reasonable?