### PR TITLE
Added missing default config 'Enabled' for ThreadSafety/NewThread

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -28,3 +28,4 @@ ThreadSafety/NewThread:
   Description: >-
                  Avoid starting new threads.
                  Let a framework like Sidekiq handle the threads.
+  Enabled: true


### PR DESCRIPTION
Avoids "ThreadSafety/NewThread does not support Enabled parameter." warning when attempting to disable cop.