### PR TITLE
[Fixes #42] implement frozen_string_literal?

### DIFF
--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -77,6 +77,8 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG = 'Freeze mutable objects assigned to class instance variables.'
+        FROZEN_STRING_LITERAL_TYPES_RUBY27 = %i[str dstr].freeze
+        FROZEN_STRING_LITERAL_TYPES_RUBY30 = %i[str].freeze
 
         def on_ivasgn(node)
           return unless in_class?(node)
@@ -126,6 +128,15 @@ module RuboCop
         end
 
         private
+
+        def frozen_string_literal?(node)
+          literal_types = if target_ruby_version >= 3.0
+                            FROZEN_STRING_LITERAL_TYPES_RUBY30
+                          else
+                            FROZEN_STRING_LITERAL_TYPES_RUBY27
+                          end
+          literal_types.include?(node.type) && frozen_string_literals_enabled?
+        end
 
         def on_assignment(value)
           if style == :strict


### PR DESCRIPTION
Allow to work with rubocop versions before and after 1.20.0

`frozen_string_literals_enabled?` is available here as of rubocop v0.47.0 so
fits with our support of `rubocop >= 0.53.0`.