### PR TITLE
Avoid require in Gemfile install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Thread-safety analysis for your projects, as an extension to
 
 ### Installation into an application
 
-Add this line to your application's Gemfile:
+Add this line to your application's Gemfile (using `require: false` as it's a standalone tool):
 
 ```ruby
-gem 'rubocop-thread_safety'
+gem 'rubocop-thread_safety', require: false
 ```
 
 Install it with Bundler by invoking:


### PR DESCRIPTION
This is advised because RuboCop is standalone and not required by the application while it is running.

Requiring the gem adds an (albeit small) amount of unnecessary overhead when loading the application.

This is also done in the README for other RuboCop tools;
- https://github.com/rubocop/rubocop#installation
- https://github.com/rubocop/rubocop-rspec#installation
- https://github.com/rubocop/rubocop-performance/#installation

