### PR TITLE
Disallow instance variables in module functions

### DIFF
--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -37,6 +37,22 @@ module RuboCop
       #       end
       #     end
       #   end
+      #
+      #   module Example
+      #     module_function
+      #
+      #     def test(params)
+      #       @params = params
+      #     end
+      #   end
+      #
+      #   module Example
+      #     def test(params)
+      #       @params = params
+      #     end
+      #
+      #     module_function :test
+      #   end
       class InstanceVariableInClassMethod < Cop
         MSG = 'Avoid instance variables in class methods.'
 
@@ -70,6 +86,7 @@ module RuboCop
           in_defs?(node) ||
             in_def_sclass?(node) ||
             in_def_class_methods?(node) ||
+            in_def_module_function?(node) ||
             singleton_method_definition?(node)
         end
 
@@ -101,6 +118,14 @@ module RuboCop
           class_methods_module?(mod)
         end
 
+        def in_def_module_function?(node)
+          defn = node.ancestors.find(&:def_type?)
+          return unless defn
+
+          defn.left_siblings.any? { |sibling| module_function_bare_access_modifier?(sibling) } ||
+            defn.right_siblings.any? { |sibling| module_function_for?(sibling, defn.method_name) }
+        end
+
         def singleton_method_definition?(node)
           node.ancestors.any? do |ancestor|
             next unless ancestor.children.first.is_a? AST::SendNode
@@ -122,8 +147,22 @@ module RuboCop
           instance_variable_set_call?(node) || instance_variable_get_call?(node)
         end
 
+        def module_function_bare_access_modifier?(node)
+          return false unless node
+
+          node.send_type? && node.bare_access_modifier? && node.method?(:module_function)
+        end
+
+        def match_name?(arg_name, method_name)
+          arg_name.to_sym == method_name.to_sym
+        end
+
         def_node_matcher :class_methods_module?, <<~PATTERN
           (module (const _ :ClassMethods) ...)
+        PATTERN
+
+        def_node_matcher :module_function_for?, <<~PATTERN
+          (send nil? {:module_function} ({sym str} #match_name?(%1)))
         PATTERN
       end
     end

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -131,6 +131,58 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
     RUBY
   end
 
+  it 'registers an offense for ivar_set in a method below module_function directive' do
+    expect_offense(<<~RUBY)
+      module Test
+        module_function
+
+        def some_method(params)
+          instance_variable_set(:@params, params)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for ivar_set in a method marked by module_function' do
+    expect_offense(<<~RUBY)
+      module Test
+        def some_method(params)
+          instance_variable_set(:@params, params)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+        end
+
+        module_function :some_method
+      end
+    RUBY
+  end
+
+  it 'registers an offense for assigning an ivar in a method below module_function directive' do
+    expect_offense(<<~RUBY)
+      module Test
+        module_function
+
+        def some_method(params)
+          @params = params
+          ^^^^^^^ Avoid instance variables in class methods.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for assigning an ivar in a method marked by module_function' do
+    expect_offense(<<~RUBY)
+      module Test
+        def some_method(params)
+          @params = params
+          ^^^^^^^ Avoid instance variables in class methods.
+        end
+
+        module_function :some_method
+      end
+    RUBY
+  end
+
   it 'registers no offense for using ivar_get on object in a class method' do
     expect_no_offenses(<<~RUBY)
       class Test
@@ -183,6 +235,34 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod do
             @params = params
           end
         end
+      end
+    RUBY
+  end
+
+  it 'registers no offense for assigning an ivar in a method above module_function directive' do
+    expect_no_offenses(<<~RUBY)
+      module Test
+        def some_method(params)
+          @params = params
+        end
+
+        module_function
+      end
+    RUBY
+  end
+
+  it 'registers no offense for assigning an ivar in a method not marked by module_function' do
+    expect_no_offenses(<<~RUBY)
+      module Test
+        def some_method(params)
+          @params = params
+        end
+
+        def another_method(params)
+          puts params
+        end
+
+        module_function :another_method
       end
     RUBY
   end


### PR DESCRIPTION
Hi. Thanks for this gem.

I found some thread-safety issues in our rails project, and then analyzed with this gem. However, I couldn't detect instance variables in module functions. As in class methods, instance variables in module functions are not thread-safe:

```ruby
module Test
  module_function

  def some_method(params)
    @params = params
  end
end
```

I added a rule to disallow instance variables in module functions to `InstanceVariableInClassMethod`. If the `MSG` is not appropriate, I will add a new class and fix it.

```ruby
module Test
  module_function

  def some_method(params)
    @params = params
    ^^^^^^^ Avoid instance variables in class methods.
  end
end
```

It seems `spec/license_spec.rb` fails. I created #47 since I'm not sure if I should fix `LICENSE.txt`.

<details><div>

```
$ bundle exec rake spec
Randomized with seed 27369
...............FF.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Failures:

  1) the LICENSE contains a copyright statement for the current year
     Failure/Error: expect(license.read).to match(/Copyright 2016-#{Date.today.year}/)
     
       expected "Copyright 2016-2021 CoverMyMeds\n\nPermission is hereby granted, free of charge, to any person obtai...ING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n" to match /Copyright 2016-2022/
       Diff:
       @@ -1,7 +1,13 @@
       -/Copyright 2016-2022/
       +Copyright 2016-2021 CoverMyMeds
       +
       +Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       +
       +The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
       +
       +THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       
     # ./spec/license_spec.rb:13:in `block (2 levels) in <top (required)>'

  2) the LICENSE is referenced from the README
     Failure/Error:
       expect(readme).to match(
         /Copyright .* 2016-#{Date.today.year}.*LICENSE.txt/m
       )
     
       expected "# RuboCop::ThreadSafety\n\nThread-safety analysis for your projects, as an extension to\n[RuboCop](h...ight\n\nCopyright (c) 2016-2021 CoverMyMeds.\nSee [LICENSE.txt](LICENSE.txt) for further details.\n" to match /Copyright .* 2016-2022.*LICENSE.txt/m
       Diff:
       @@ -1,76 +1,151 @@
       -/Copyright .* 2016-2022.*LICENSE.txt/m
       +# RuboCop::ThreadSafety
       +
       +Thread-safety analysis for your projects, as an extension to
       +[RuboCop](https://github.com/bbatsov/rubocop).
       +
       +## Installation and Usage
       +
       +### Installation into an application
       +
       +Add this line to your application's Gemfile (using `require: false` as it's a standalone tool):
       +
       +```ruby
       +gem 'rubocop-thread_safety', require: false
       +```
       +
       +Install it with Bundler by invoking:
       +
       +    $ bundle
       +
       +Add this line to your application's `.rubocop.yml`:
       +
       +    require: rubocop-thread_safety
       +
       +Now you can run `rubocop` and it will automatically load the RuboCop
       +Thread-Safety cops together with the standard cops.
       +
       +### Scanning an application without adding it to the Gemfile
       +
       +Install the gem:
       +
       +    $ gem install rubocop-thread_safety
       +
       +Scan the application for just thread-safety issues:
       +
       +    $ rubocop -r rubocop-thread_safety --only ThreadSafety,Style/GlobalVars,Style/ClassVars,Style/MutableConstant
       +
       +### Configuration
       +
       +There are some added [configuration options](https://github.com/covermymeds/rubocop-thread_safety/blob/master/config/default.yml) that can be tweaked to modify the behaviour of these thread-safety cops.
       +
       +### Correcting code for thread-safety
       +
       +There are a few ways to improve thread-safety that stem around avoiding
       +unsynchronized mutation of state that is shared between multiple threads.
       +
       +State shared between threads may take various forms, including:
       +
       +* Class variables (`@@name`). Note: these affect child classes too.
       +* Class instance variables (`@name` in class context or class methods)
       +* Constants (`NAME`). Ruby will warn if a constant is re-assigned to a new value but will allow it. Mutable objects can still be mutated (e.g. push to an array) even if they are assigned to a constant.
       +* Globals (`$name`), with the possible exception of some special globals provided by ruby that are documented as thread-local like regular expression results.
       +* Variables in the scope of created threads (where `Thread.new` is called).
       +
       +Improvements that would make shared state thread-safe include:
       +
       +* `freeze` objects to protect against mutation. Note: `freeze` is shallow, i.e. freezing an array will not also freeze its elements.
       +* Use data structures or concurrency abstractions from [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby), e.g. `Concurrent::Map`
       +* Use a `Mutex` or similar to `synchronize` access.
       +* Use [`ActiveSupport::CurrentAttributes`](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html)
       +* Use [`RequestStore`](https://github.com/steveklabnik/request_store)
       +* Use `Thread.current[:name]`
       +
       +## Development
       +
       +After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
       +
       +To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
       +
       +## Contributing
       +
       +Bug reports and pull requests are welcome on GitHub at https://github.com/covermymeds/rubocop-thread_safety.
       +
       +## Copyright
       +
       +Copyright (c) 2016-2021 CoverMyMeds.
       +See [LICENSE.txt](LICENSE.txt) for further details.
       
     # ./spec/license_spec.rb:18:in `block (2 levels) in <top (required)>'

Finished in 1.97 seconds (files took 2.53 seconds to load)
538 examples, 2 failures

Failed examples:

rspec ./spec/license_spec.rb:12 # the LICENSE contains a copyright statement for the current year
rspec ./spec/license_spec.rb:16 # the LICENSE is referenced from the README

Randomized with seed 27369
```
</div></details>