### PR TITLE
Improve performance with RESTRICT_ON_SEND

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -14,6 +14,12 @@ module RuboCop
       #   end
       class ClassAndModuleAttributes < Cop
         MSG = 'Avoid mutating class and module attributes.'
+        RESTRICT_ON_SEND = %i[
+          mattr_writer mattr_accessor cattr_writer cattr_accessor
+          class_attribute
+          attr attr_accessor attr_writer
+          attr_internal attr_internal_accessor attr_internal_writer
+        ].freeze
 
         def_node_matcher :mattr?, <<~MATCHER
           (send nil?

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -55,6 +55,10 @@ module RuboCop
       #   end
       class InstanceVariableInClassMethod < Cop
         MSG = 'Avoid instance variables in class methods.'
+        RESTRICT_ON_SEND = %i[
+          instance_variable_set
+          instance_variable_get
+        ].freeze
 
         def_node_matcher :instance_variable_set_call?, <<~MATCHER
           (send nil? :instance_variable_set (...) (...))

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -12,6 +12,7 @@ module RuboCop
       #   Thread.new { do_work }
       class NewThread < Cop
         MSG = 'Avoid starting new threads.'
+        RESTRICT_ON_SEND = %i[new].freeze
 
         def_node_matcher :new_thread?, <<~MATCHER
           (send (const {nil? cbase} :Thread) :new)


### PR DESCRIPTION
https://github.com/rubocop/rubocop/blob/master/docs/modules/ROOT/pages/development.adoc#implementation mentions:

> The `on_send` callback is the most used and can be optimized by restricting the acceptable method names with a constant `RESTRICT_ON_SEND`.